### PR TITLE
fix: rerun gallery config migration

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "nest build",
     "dev": "cross-env NODE_ENV=development nest start --watch",
-    "prod": "prisma migrate deploy && prisma db seed && node dist/src/main",
+    "prod": "prisma migrate resolve --rolled-back 20250915000000_gallery_default_config || true && prisma migrate deploy && prisma db seed && node dist/src/main",
     "lint": "eslint 'src/**/*.ts'",
     "format": "prettier --end-of-line=auto --write 'src/**/*.ts'",
     "test:system": "prisma migrate reset -f && nest start & wait-on http://localhost:8080/api/configs && newman run ./test/newman-system-tests.json"


### PR DESCRIPTION
## Summary
- rerun gallery default config migration before backend startup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9900758e4832b8714bfd3322b1ca6