### PR TITLE
feat(frontend): improve share download view

### DIFF
--- a/frontend/src/i18n/translations/ar-EG.ts
+++ b/frontend/src/i18n/translations/ar-EG.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "تنزيل الكل",
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "رابط الملف",
   "share.table.name": "الاسم",
   "share.table.size": "الحجم",

--- a/frontend/src/i18n/translations/cs-CZ.ts
+++ b/frontend/src/i18n/translations/cs-CZ.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Stáhnout vše",
   "share.notify.download-all-preparing": "Sdílení se připravuje. Zkuste to prosím znovu za několik minut.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Odkaz na soubor",
   "share.table.name": "Název",
   "share.table.size": "Velikost",

--- a/frontend/src/i18n/translations/da-DK.ts
+++ b/frontend/src/i18n/translations/da-DK.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Download alle",
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Fil link",
   "share.table.name": "Navn",
   "share.table.size": "Størrelse",

--- a/frontend/src/i18n/translations/de-DE.ts
+++ b/frontend/src/i18n/translations/de-DE.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Alles herunterladen",
   "share.notify.download-all-preparing": "Die Freigabe wird vorbereitet. Bitte versuche es in ein paar Minuten erneut.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Dateilink",
   "share.table.name": "Name",
   "share.table.size": "Größe",

--- a/frontend/src/i18n/translations/el-GR.ts
+++ b/frontend/src/i18n/translations/el-GR.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Λήψη όλων",
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Σύνδεσμος αρχείου",
   "share.table.name": "Όνομα",
   "share.table.size": "Μέγεθος",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -390,6 +390,10 @@ export default {
   "share.button.download-all": "Download all",
   "share.notify.download-all-preparing":
     "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
 
   "share.modal.file-link": "File link",
   "share.table.name": "Name",

--- a/frontend/src/i18n/translations/es-ES.ts
+++ b/frontend/src/i18n/translations/es-ES.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Descargar todo",
   "share.notify.download-all-preparing": "El enlace compartido está en preparación. Por favor, inténtalo de nuevo en unos minutos.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Enlace del archivo",
   "share.table.name": "Nombre",
   "share.table.size": "Tamaño",

--- a/frontend/src/i18n/translations/et-EE.ts
+++ b/frontend/src/i18n/translations/et-EE.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Laadi kõik alla",
   "share.notify.download-all-preparing": "Jagamist valmistatakse ette. Palun proovi mõne minuti pärast uuesti.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Faili link",
   "share.table.name": "Nimi",
   "share.table.size": "Suurus",

--- a/frontend/src/i18n/translations/fi-FI.ts
+++ b/frontend/src/i18n/translations/fi-FI.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Lataa kaikki",
   "share.notify.download-all-preparing": "Jako on valmistumassa. Yritä uudelleen muutaman minuutin kuluttua.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Tiedoston linkki",
   "share.table.name": "Nimi",
   "share.table.size": "Koko",

--- a/frontend/src/i18n/translations/fr-FR.ts
+++ b/frontend/src/i18n/translations/fr-FR.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Télécharger tout",
   "share.notify.download-all-preparing": "Le partage est en préparation. Réessayez dans quelques minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Lien du fichier",
   "share.table.name": "Nom",
   "share.table.size": "Taille",

--- a/frontend/src/i18n/translations/hr-HR.ts
+++ b/frontend/src/i18n/translations/hr-HR.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Preuzmi sve",
   "share.notify.download-all-preparing": "Dijeljenje se priprema. Molimo pokušajte ponovo za nekoliko minuta.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Poveznica datoteke",
   "share.table.name": "Naziv",
   "share.table.size": "Veličina",

--- a/frontend/src/i18n/translations/hu-HU.ts
+++ b/frontend/src/i18n/translations/hu-HU.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Mindet letölti",
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Fájl hivatkozás",
   "share.table.name": "Megnevezés",
   "share.table.size": "Méret",

--- a/frontend/src/i18n/translations/it-IT.ts
+++ b/frontend/src/i18n/translations/it-IT.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Scarica tutto",
   "share.notify.download-all-preparing": "La condivisione è in preparazione. Riprova tra qualche minuto.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Link dei File",
   "share.table.name": "Nome",
   "share.table.size": "Dimensione",

--- a/frontend/src/i18n/translations/ja-JP.ts
+++ b/frontend/src/i18n/translations/ja-JP.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "全てダウンロード",
   "share.notify.download-all-preparing": "共有の準備中です。数分後にもう一度お試しください。",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "ファイルリンク",
   "share.table.name": "ファイル名",
   "share.table.size": "サイズ",

--- a/frontend/src/i18n/translations/ko-KR.ts
+++ b/frontend/src/i18n/translations/ko-KR.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "모두 다운로드",
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "파일 링크",
   "share.table.name": "이름",
   "share.table.size": "크기",

--- a/frontend/src/i18n/translations/nl-BE.ts
+++ b/frontend/src/i18n/translations/nl-BE.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Alles downloaden",
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Link naar bestand",
   "share.table.name": "Naam",
   "share.table.size": "Grootte",

--- a/frontend/src/i18n/translations/pl-PL.ts
+++ b/frontend/src/i18n/translations/pl-PL.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Pobierz wszystko",
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Link do pliku",
   "share.table.name": "Nazwa",
   "share.table.size": "Rozmiar",

--- a/frontend/src/i18n/translations/pt-BR.ts
+++ b/frontend/src/i18n/translations/pt-BR.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Transferir tudo",
   "share.notify.download-all-preparing": "O compartilhamento está sendo preparado. Tente novamente em alguns minutos.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Link do arquivo",
   "share.table.name": "Nome",
   "share.table.size": "Tamanho",

--- a/frontend/src/i18n/translations/ru-RU.ts
+++ b/frontend/src/i18n/translations/ru-RU.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Скачать все",
   "share.notify.download-all-preparing": "Загрузка готовится. Повторите попытку через несколько минут.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Ссылка на файл",
   "share.table.name": "Название",
   "share.table.size": "Размер",

--- a/frontend/src/i18n/translations/sl-SI.ts
+++ b/frontend/src/i18n/translations/sl-SI.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Prenesi vse",
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Povezava do datoteke",
   "share.table.name": "Ime",
   "share.table.size": "Velikost",

--- a/frontend/src/i18n/translations/sr-CS.ts
+++ b/frontend/src/i18n/translations/sr-CS.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Preuzmi sve",
   "share.notify.download-all-preparing": "Deljenje se priprema. Molimo pokušajte ponovo za nekoliko minuta.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Veza datoteke",
   "share.table.name": "Naziv",
   "share.table.size": "Veličina",

--- a/frontend/src/i18n/translations/sr-SP.ts
+++ b/frontend/src/i18n/translations/sr-SP.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Преузми све",
   "share.notify.download-all-preparing": "Дељење се припрема. Молимо покушајте поново за неколико минута.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Веза датотеке",
   "share.table.name": "Назив",
   "share.table.size": "Величина",

--- a/frontend/src/i18n/translations/sv-SE.ts
+++ b/frontend/src/i18n/translations/sv-SE.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Ladda ner allt",
   "share.notify.download-all-preparing": "Delningen förbereds. Försök igen om några minuter.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Fillänk",
   "share.table.name": "Namn",
   "share.table.size": "Storlek",

--- a/frontend/src/i18n/translations/th-TH.ts
+++ b/frontend/src/i18n/translations/th-TH.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "ดาวน์โหลดทั้งหมด",
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "ลิงค์ไฟล์",
   "share.table.name": "ชื่อ",
   "share.table.size": "ขนาด",

--- a/frontend/src/i18n/translations/tr-TR.ts
+++ b/frontend/src/i18n/translations/tr-TR.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Tümünü indir",
   "share.notify.download-all-preparing": "Paylaşım hazırlanıyor. Lütfen birkaç dakika içinde tekrar deneyin.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Dosya bağlantısı",
   "share.table.name": "İsim",
   "share.table.size": "Boyut",

--- a/frontend/src/i18n/translations/uk-UA.ts
+++ b/frontend/src/i18n/translations/uk-UA.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Завантажити все",
   "share.notify.download-all-preparing": "Завантаження готується. Будь ласка, спробуйте знову через кілька хвилин.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Посилання на файл",
   "share.table.name": "Назва",
   "share.table.size": "Розмір",

--- a/frontend/src/i18n/translations/vi-VN.ts
+++ b/frontend/src/i18n/translations/vi-VN.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "Tải xuống tất cả",
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "File link",
   "share.table.name": "Tên",
   "share.table.size": "Kích thước",

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "全部下载",
   "share.notify.download-all-preparing": "该共享正在处理中，请稍等片刻。",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "文件链接",
   "share.table.name": "文件名",
   "share.table.size": "文件大小",

--- a/frontend/src/i18n/translations/zh-TW.ts
+++ b/frontend/src/i18n/translations/zh-TW.ts
@@ -286,6 +286,10 @@ export default {
   "share.button.download": "Download",
   "share.button.download-all": "全部下載",
   "share.notify.download-all-preparing": "正在處理中，請稍等片刻",
+  "share.allFiles": "All files",
+  "share.gallery.title": "Gallery",
+  "share.gallery.description":
+    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "檔案連結",
   "share.table.name": "檔案名稱",
   "share.table.size": "檔案大小",


### PR DESCRIPTION
## Summary
- localize All files and Gallery headings on share download page
- explain and restrict gallery to JPEG files
- streamline gallery subheadings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a config file)


------
https://chatgpt.com/codex/tasks/task_e_68a98ca15548832ba66b678e75310d0c