### PR TITLE
Revamp share downloads layout and add image share overlay

### DIFF
--- a/frontend/src/i18n/translations/ar-EG.ts
+++ b/frontend/src/i18n/translations/ar-EG.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "رابط الملف",
   "share.table.name": "الاسم",
   "share.table.size": "الحجم",

--- a/frontend/src/i18n/translations/cs-CZ.ts
+++ b/frontend/src/i18n/translations/cs-CZ.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Sdílení se připravuje. Zkuste to prosím znovu za několik minut.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Odkaz na soubor",
   "share.table.name": "Název",
   "share.table.size": "Velikost",

--- a/frontend/src/i18n/translations/da-DK.ts
+++ b/frontend/src/i18n/translations/da-DK.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Fil link",
   "share.table.name": "Navn",
   "share.table.size": "Størrelse",

--- a/frontend/src/i18n/translations/de-DE.ts
+++ b/frontend/src/i18n/translations/de-DE.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Die Freigabe wird vorbereitet. Bitte versuche es in ein paar Minuten erneut.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Dateilink",
   "share.table.name": "Name",
   "share.table.size": "Größe",

--- a/frontend/src/i18n/translations/el-GR.ts
+++ b/frontend/src/i18n/translations/el-GR.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Σύνδεσμος αρχείου",
   "share.table.name": "Όνομα",
   "share.table.size": "Μέγεθος",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -392,8 +392,6 @@ export default {
     "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
 
   "share.modal.file-link": "File link",
   "share.table.name": "Name",

--- a/frontend/src/i18n/translations/es-ES.ts
+++ b/frontend/src/i18n/translations/es-ES.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "El enlace compartido está en preparación. Por favor, inténtalo de nuevo en unos minutos.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Enlace del archivo",
   "share.table.name": "Nombre",
   "share.table.size": "Tamaño",

--- a/frontend/src/i18n/translations/et-EE.ts
+++ b/frontend/src/i18n/translations/et-EE.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Jagamist valmistatakse ette. Palun proovi mõne minuti pärast uuesti.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Faili link",
   "share.table.name": "Nimi",
   "share.table.size": "Suurus",

--- a/frontend/src/i18n/translations/fi-FI.ts
+++ b/frontend/src/i18n/translations/fi-FI.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Jako on valmistumassa. Yritä uudelleen muutaman minuutin kuluttua.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Tiedoston linkki",
   "share.table.name": "Nimi",
   "share.table.size": "Koko",

--- a/frontend/src/i18n/translations/fr-FR.ts
+++ b/frontend/src/i18n/translations/fr-FR.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Le partage est en préparation. Réessayez dans quelques minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Lien du fichier",
   "share.table.name": "Nom",
   "share.table.size": "Taille",

--- a/frontend/src/i18n/translations/hr-HR.ts
+++ b/frontend/src/i18n/translations/hr-HR.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Dijeljenje se priprema. Molimo pokušajte ponovo za nekoliko minuta.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Poveznica datoteke",
   "share.table.name": "Naziv",
   "share.table.size": "Veličina",

--- a/frontend/src/i18n/translations/hu-HU.ts
+++ b/frontend/src/i18n/translations/hu-HU.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Fájl hivatkozás",
   "share.table.name": "Megnevezés",
   "share.table.size": "Méret",

--- a/frontend/src/i18n/translations/it-IT.ts
+++ b/frontend/src/i18n/translations/it-IT.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "La condivisione è in preparazione. Riprova tra qualche minuto.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Link dei File",
   "share.table.name": "Nome",
   "share.table.size": "Dimensione",

--- a/frontend/src/i18n/translations/ja-JP.ts
+++ b/frontend/src/i18n/translations/ja-JP.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "共有の準備中です。数分後にもう一度お試しください。",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "ファイルリンク",
   "share.table.name": "ファイル名",
   "share.table.size": "サイズ",

--- a/frontend/src/i18n/translations/ko-KR.ts
+++ b/frontend/src/i18n/translations/ko-KR.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "파일 링크",
   "share.table.name": "이름",
   "share.table.size": "크기",

--- a/frontend/src/i18n/translations/nl-BE.ts
+++ b/frontend/src/i18n/translations/nl-BE.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Link naar bestand",
   "share.table.name": "Naam",
   "share.table.size": "Grootte",

--- a/frontend/src/i18n/translations/pl-PL.ts
+++ b/frontend/src/i18n/translations/pl-PL.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Link do pliku",
   "share.table.name": "Nazwa",
   "share.table.size": "Rozmiar",

--- a/frontend/src/i18n/translations/pt-BR.ts
+++ b/frontend/src/i18n/translations/pt-BR.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "O compartilhamento está sendo preparado. Tente novamente em alguns minutos.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Link do arquivo",
   "share.table.name": "Nome",
   "share.table.size": "Tamanho",

--- a/frontend/src/i18n/translations/ru-RU.ts
+++ b/frontend/src/i18n/translations/ru-RU.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Загрузка готовится. Повторите попытку через несколько минут.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Ссылка на файл",
   "share.table.name": "Название",
   "share.table.size": "Размер",

--- a/frontend/src/i18n/translations/sl-SI.ts
+++ b/frontend/src/i18n/translations/sl-SI.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Povezava do datoteke",
   "share.table.name": "Ime",
   "share.table.size": "Velikost",

--- a/frontend/src/i18n/translations/sr-CS.ts
+++ b/frontend/src/i18n/translations/sr-CS.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Deljenje se priprema. Molimo pokušajte ponovo za nekoliko minuta.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Veza datoteke",
   "share.table.name": "Naziv",
   "share.table.size": "Veličina",

--- a/frontend/src/i18n/translations/sr-SP.ts
+++ b/frontend/src/i18n/translations/sr-SP.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Дељење се припрема. Молимо покушајте поново за неколико минута.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Веза датотеке",
   "share.table.name": "Назив",
   "share.table.size": "Величина",

--- a/frontend/src/i18n/translations/sv-SE.ts
+++ b/frontend/src/i18n/translations/sv-SE.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Delningen förbereds. Försök igen om några minuter.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Fillänk",
   "share.table.name": "Namn",
   "share.table.size": "Storlek",

--- a/frontend/src/i18n/translations/th-TH.ts
+++ b/frontend/src/i18n/translations/th-TH.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "ลิงค์ไฟล์",
   "share.table.name": "ชื่อ",
   "share.table.size": "ขนาด",

--- a/frontend/src/i18n/translations/tr-TR.ts
+++ b/frontend/src/i18n/translations/tr-TR.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Paylaşım hazırlanıyor. Lütfen birkaç dakika içinde tekrar deneyin.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Dosya bağlantısı",
   "share.table.name": "İsim",
   "share.table.size": "Boyut",

--- a/frontend/src/i18n/translations/uk-UA.ts
+++ b/frontend/src/i18n/translations/uk-UA.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "Завантаження готується. Будь ласка, спробуйте знову через кілька хвилин.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "Посилання на файл",
   "share.table.name": "Назва",
   "share.table.size": "Розмір",

--- a/frontend/src/i18n/translations/vi-VN.ts
+++ b/frontend/src/i18n/translations/vi-VN.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "The share is being prepared. Please try again in a few minutes.",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "File link",
   "share.table.name": "Tên",
   "share.table.size": "Kích thước",

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "该共享正在处理中，请稍等片刻。",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "文件链接",
   "share.table.name": "文件名",
   "share.table.size": "文件大小",

--- a/frontend/src/i18n/translations/zh-TW.ts
+++ b/frontend/src/i18n/translations/zh-TW.ts
@@ -288,8 +288,6 @@ export default {
   "share.notify.download-all-preparing": "正在處理中，請稍等片刻",
   "share.allFiles": "All files",
   "share.gallery.title": "Gallery",
-  "share.gallery.description":
-    "Here are all the individual jpegs for simple viewing and downloading one at a time! You can also download the entire collection of jpegs or uncompressed tiffs with the links above.",
   "share.modal.file-link": "檔案連結",
   "share.table.name": "檔案名稱",
   "share.table.size": "檔案大小",


### PR DESCRIPTION
## Summary
- Replace share name and All files heading with unified Downloads section
- Remove gallery description text and cleanup translations
- Overlay share button on gallery images for native sharing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*


------
https://chatgpt.com/codex/tasks/task_e_68a9966cdb10832baaf281ab97d3a0ab