### PR TITLE
fix: use iOS share panel for images

### DIFF
--- a/frontend/src/components/share/FileList.tsx
+++ b/frontend/src/components/share/FileList.tsx
@@ -99,13 +99,20 @@ const FileList = ({
     }
 
     try {
-      const response = await fetch(url);
-      const blob = await response.blob();
-      const mimeType =
-        blob.type || (mime.contentType(file.name) as string) || "";
-      await navigator.share({
-        files: [new File([blob], file.name, { type: mimeType })],
-      });
+      if (
+        navigator.canShare &&
+        navigator.canShare({ files: [new File([], file.name)] })
+      ) {
+        const response = await fetch(url);
+        const blob = await response.blob();
+        const mimeType =
+          blob.type || (mime.contentType(file.name) as string) || "";
+        await navigator.share({
+          files: [new File([blob], file.name, { type: mimeType })],
+        });
+      } else {
+        await navigator.share({ url });
+      }
     } catch {
       await shareService.downloadFile(share.id, file.id);
     }


### PR DESCRIPTION
## Summary
- ensure image share icon opens native share sheet when file sharing isn't supported

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68a99c06871c832b88d736b13d0987fb