### PR TITLE
feat: enable gallery per zip file

### DIFF
--- a/backend/prisma/migrations/20251001000000_move_gallery_to_file/migration.sql
+++ b/backend/prisma/migrations/20251001000000_move_gallery_to_file/migration.sql
@@ -1,0 +1,28 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_Share" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "name" TEXT,
+    "uploadLocked" BOOLEAN NOT NULL DEFAULT false,
+    "isZipReady" BOOLEAN NOT NULL DEFAULT false,
+    "views" INTEGER NOT NULL DEFAULT 0,
+    "expiration" DATETIME NOT NULL,
+    "description" TEXT,
+    "removedReason" TEXT,
+    "creatorId" TEXT,
+    "reverseShareId" TEXT,
+    "storageProvider" TEXT NOT NULL DEFAULT 'LOCAL',
+    CONSTRAINT "Share_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Share_reverseShareId_fkey" FOREIGN KEY ("reverseShareId") REFERENCES "ReverseShare" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Share" ("createdAt", "creatorId", "description", "expiration", "id", "isZipReady", "name", "removedReason", "reverseShareId", "storageProvider", "uploadLocked", "views") SELECT "createdAt", "creatorId", "description", "expiration", "id", "isZipReady", "name", "removedReason", "reverseShareId", "storageProvider", "uploadLocked", "views" FROM "Share";
+DROP TABLE "Share";
+ALTER TABLE "new_Share" RENAME TO "Share";
+
+ALTER TABLE "File" ADD COLUMN "isGallery" BOOLEAN NOT NULL DEFAULT false;
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/migrations/20251002000000_gallery_filename_regex/migration.sql
+++ b/backend/prisma/migrations/20251002000000_gallery_filename_regex/migration.sql
@@ -1,0 +1,7 @@
+DELETE FROM "Config" WHERE "name" = 'enableByDefault' AND "category" = 'gallery';
+
+INSERT INTO "Config" ("name", "category", "type", "defaultValue", "value", "obscured", "secret", "locked", "order", "updatedAt")
+SELECT 'filenameRegex', 'gallery', 'string', 'jpegs?\\.zip$', NULL, false, false, false, 0, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM "Config" WHERE "name" = 'filenameRegex' AND "category" = 'gallery'
+);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -96,7 +96,6 @@ model Share {
   recipients ShareRecipient[]
   files      File[]
   storageProvider String @default("LOCAL")
-  isGallery Boolean @default(false)
 }
 
 model ReverseShare {
@@ -134,6 +133,7 @@ model File {
 
   shareId String
   share   Share  @relation(fields: [shareId], references: [id], onDelete: Cascade)
+  isGallery Boolean @default(false)
 }
 
 model ShareSecurity {

--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -77,9 +77,9 @@ export const configVariables = {
     },
   },
   gallery: {
-    enableByDefault: {
-      type: "boolean",
-      defaultValue: "true",
+    filenameRegex: {
+      type: "string",
+      defaultValue: "jpegs?\\.zip$",
       secret: false,
     },
   },

--- a/backend/src/file/dto/file.dto.ts
+++ b/backend/src/file/dto/file.dto.ts
@@ -11,6 +11,9 @@ export class FileDTO {
   @Expose()
   size: string;
 
+  @Expose()
+  isGallery: boolean;
+
   share: ShareDTO;
 
   from(partial: Partial<FileDTO>) {

--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -33,17 +33,18 @@ export class FileController {
       name: string;
       chunkIndex: string;
       totalChunks: string;
+      isGallery?: string;
     },
     @Body() body: string,
     @Param("shareId") shareId: string,
   ) {
-    const { id, name, chunkIndex, totalChunks } = query;
+    const { id, name, chunkIndex, totalChunks, isGallery } = query;
 
     // Data can be empty if the file is empty
     return await this.fileService.create(
       body,
       { index: parseInt(chunkIndex), total: parseInt(totalChunks) },
-      { id, name },
+      { id, name, isGallery: isGallery === "true" },
       shareId,
     );
   }

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -34,6 +34,7 @@ export class FileService {
     file: {
       id?: string;
       name: string;
+      isGallery?: boolean;
     },
     shareId: string,
   ) {

--- a/backend/src/file/local.service.ts
+++ b/backend/src/file/local.service.ts
@@ -26,7 +26,7 @@ export class LocalFileService {
   async create(
     data: string,
     chunk: { index: number; total: number },
-    file: { id?: string; name: string },
+    file: { id?: string; name: string; isGallery?: boolean },
     shareId: string,
   ) {
     if (!file.id) {
@@ -110,6 +110,7 @@ export class LocalFileService {
           id: file.id,
           name: file.name,
           size: fileSize.toString(),
+          isGallery: file.isGallery ?? false,
           share: { connect: { id: shareId } },
         },
       });

--- a/backend/src/file/s3.service.ts
+++ b/backend/src/file/s3.service.ts
@@ -47,7 +47,7 @@ export class S3FileService {
   async create(
     data: string,
     chunk: { index: number; total: number },
-    file: { id?: string; name: string },
+    file: { id?: string; name: string; isGallery?: boolean },
     shareId: string,
   ) {
     if (!file.id) {
@@ -158,6 +158,7 @@ export class S3FileService {
           id: file.id,
           name: file.name,
           size: fileSize.toString(),
+          isGallery: file.isGallery ?? false,
           share: { connect: { id: shareId } },
         },
       });

--- a/backend/src/share/dto/createShare.dto.ts
+++ b/backend/src/share/dto/createShare.dto.ts
@@ -3,7 +3,6 @@ import {
   IsEmail,
   IsOptional,
   IsString,
-  IsBoolean,
   Length,
   Matches,
   MaxLength,
@@ -37,7 +36,4 @@ export class CreateShareDTO {
   @Type(() => ShareSecurityDTO)
   security: ShareSecurityDTO;
 
-  @IsOptional()
-  @IsBoolean()
-  isGallery?: boolean;
 }

--- a/backend/src/share/dto/share.dto.ts
+++ b/backend/src/share/dto/share.dto.ts
@@ -29,9 +29,6 @@ export class ShareDTO {
   @Expose()
   size: number;
 
-  @Expose()
-  isGallery: boolean;
-
   from(partial: Partial<ShareDTO>) {
     return plainToClass(ShareDTO, partial, { excludeExtraneousValues: true });
   }

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -73,10 +73,6 @@ export class ShareService {
       expirationDate = parsedExpiration;
     }
 
-    if (share.isGallery === undefined) {
-      share.isGallery = this.config.get("gallery.enableByDefault");
-    }
-
     fs.mkdirSync(`${SHARE_DIRECTORY}/${share.id}`, {
       recursive: true,
     });
@@ -140,7 +136,9 @@ export class ShareService {
   }
 
   private async extractGalleryZips(share: Share & { files: PrismaFile[] }) {
-    const zipFiles = share.files.filter((f) => f.name.endsWith(".zip"));
+    const zipFiles = share.files.filter(
+      (f) => f.name.endsWith(".zip") && f.isGallery,
+    );
     for (const zipFile of zipFiles) {
       const zipPath = `${SHARE_DIRECTORY}/${share.id}/${zipFile.id}`;
       const extractDir = `${SHARE_DIRECTORY}/${share.id}/__tmp_extract_${zipFile.id}`;
@@ -198,7 +196,9 @@ export class ShareService {
         "You need at least on file in your share to complete it.",
       );
 
-    if (share.isGallery) {
+    if (
+      share.files.some((f) => f.isGallery && f.name.endsWith(".zip"))
+    ) {
       await this.extractGalleryZips(share);
     }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,8 +30,8 @@ share:
   #The share creation modal automatically appears when a user selects files, eliminating the need to manually click the button.
   autoOpenShareModal: "false"
 gallery:
-  #Whether new shares are created with gallery enabled by default
-  enableByDefault: "true"
+  # Regex (case-insensitive) for ZIP filenames that should enable gallery by default
+  filenameRegex: "jpegs?\\.zip$"
 cache:
   #Normally Pingvin Share caches information in memory. If you run multiple instances of Pingvin Share, you need to enable Redis caching to share the cache between the instances.
   redis-enabled: "false"

--- a/frontend/src/components/upload/FileList.tsx
+++ b/frontend/src/components/upload/FileList.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Table } from "@mantine/core";
+import { ActionIcon, Table, Checkbox } from "@mantine/core";
 import { TbTrash } from "react-icons/tb";
 import { GrUndo } from "react-icons/gr";
 import { FileListItem } from "../../types/File.type";
@@ -10,10 +10,12 @@ const FileListRow = ({
   file,
   onRemove,
   onRestore,
+  onToggleGallery,
 }: {
   file: FileListItem;
   onRemove?: () => void;
   onRestore?: () => void;
+  onToggleGallery?: (checked: boolean) => void;
 }) => {
   {
     const uploadable = "uploadingProgress" in file;
@@ -33,6 +35,14 @@ const FileListRow = ({
       >
         <td>{file.name}</td>
         <td>{byteToHumanSizeString(+file.size)}</td>
+        <td>
+          {uploadable && file.name.endsWith(".zip") && (
+            <Checkbox
+              checked={!!file.isGallery}
+              onChange={(e) => onToggleGallery?.(e.currentTarget.checked)}
+            />
+          )}
+        </td>
         <td>
           {removable && (
             <ActionIcon
@@ -94,12 +104,21 @@ const FileList = <T extends FileListItem = FileListItem>({
     setFiles([...files]);
   };
 
+  const toggleGallery = (index: number, value: boolean) => {
+    const file = files[index];
+    if ("uploadingProgress" in file) {
+      file.isGallery = value;
+    }
+    setFiles([...files]);
+  };
+
   const rows = files.map((file, i) => (
     <FileListRow
       key={i}
       file={file}
       onRemove={() => remove(i)}
       onRestore={() => restore(i)}
+      onToggleGallery={(checked) => toggleGallery(i, checked)}
     />
   ));
 
@@ -112,6 +131,9 @@ const FileList = <T extends FileListItem = FileListItem>({
           </th>
           <th>
             <FormattedMessage id="upload.filelist.size" />
+          </th>
+          <th>
+            <FormattedMessage id="upload.modal.gallery" />
           </th>
           <th></th>
         </tr>

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -43,7 +43,6 @@ const showCreateUploadModal = (
     maxExpiration: Timespan;
     shareIdLength: number;
     simplified: boolean;
-    galleryEnabledByDefault: boolean;
   },
   files: FileUpload[],
   uploadCallback: (createShare: CreateShare, files: FileUpload[]) => void,
@@ -116,7 +115,6 @@ const CreateUploadModalBody = ({
     enableEmailRecepients: boolean;
     maxExpiration: Timespan;
     shareIdLength: number;
-    galleryEnabledByDefault: boolean;
   };
 }) => {
   const modals = useModals();
@@ -149,7 +147,6 @@ const CreateUploadModalBody = ({
       .number()
       .transform((value) => value || undefined)
       .min(1),
-    isGallery: yup.boolean(),
   });
 
   const form = useForm({
@@ -160,7 +157,6 @@ const CreateUploadModalBody = ({
       password: undefined,
       maxViews: undefined,
       description: undefined,
-      isGallery: options.galleryEnabledByDefault,
       expiration_num: 1,
       expiration_unit: "-days",
       never_expires: false,
@@ -212,7 +208,6 @@ const CreateUploadModalBody = ({
           expiration: expirationString,
           recipients: values.recipients,
           description: values.description,
-          isGallery: values.isGallery,
           security: {
             password: values.password || undefined,
             maxViews: values.maxViews || undefined,
@@ -359,10 +354,6 @@ const CreateUploadModalBody = ({
               </Text>
             </>
           )}
-          <Checkbox
-            label={t("upload.modal.gallery")}
-            {...form.getInputProps("isGallery", { type: "checkbox" })}
-          />
           <Accordion>
             <Accordion.Item value="description" sx={{ borderBottom: "none" }}>
               <Accordion.Control>
@@ -493,7 +484,6 @@ const SimplifiedCreateUploadModalModal = ({
     enableEmailRecepients: boolean;
     maxExpiration: Timespan;
     shareIdLength: number;
-    galleryEnabledByDefault: boolean;
   };
 }) => {
   const modals = useModals();
@@ -507,14 +497,12 @@ const SimplifiedCreateUploadModalModal = ({
       .transform((value) => value || undefined)
       .min(3, t("common.error.too-short", { length: 3 }))
       .max(30, t("common.error.too-long", { length: 30 })),
-    isGallery: yup.boolean(),
   });
 
   const form = useForm({
     initialValues: {
       name: undefined,
       description: undefined,
-      isGallery: options.galleryEnabledByDefault,
     },
     validate: yupResolver(validationSchema),
   });
@@ -538,7 +526,6 @@ const SimplifiedCreateUploadModalModal = ({
         expiration: "never",
         recipients: [],
         description: values.description,
-        isGallery: values.isGallery,
         security: {
           password: undefined,
           maxViews: undefined,
@@ -580,10 +567,6 @@ const SimplifiedCreateUploadModalModal = ({
               {...form.getInputProps("description")}
             />
           </Stack>
-          <Checkbox
-            label={t("upload.modal.gallery")}
-            {...form.getInputProps("isGallery", { type: "checkbox" })}
-          />
           <Button type="submit" data-autofocus>
             <FormattedMessage id="common.button.share" />
           </Button>

--- a/frontend/src/i18n/translations/ar-EG.ts
+++ b/frontend/src/i18n/translations/ar-EG.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "يجب أن يكون رقماً",
   "common.error.field-required": "هذا الحقل مطلوب",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/cs-CZ.ts
+++ b/frontend/src/i18n/translations/cs-CZ.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Musí být číslo",
   "common.error.field-required": "Toto pole je povinné",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/da-DK.ts
+++ b/frontend/src/i18n/translations/da-DK.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Skal være et tal",
   "common.error.field-required": "Dette felt er påkrævet",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/de-DE.ts
+++ b/frontend/src/i18n/translations/de-DE.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Muss eine Zahl sein",
   "common.error.field-required": "Dieses Feld ist erforderlich",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/el-GR.ts
+++ b/frontend/src/i18n/translations/el-GR.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Πρέπει να είναι αριθμός",
   "common.error.field-required": "Αυτό το πεδίο είναι υποχρεωτικό",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -764,7 +764,7 @@ export default {
   "common.error.invalid-number": "Must be a number",
   "common.error.field-required": "This field is required",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };
 

--- a/frontend/src/i18n/translations/es-ES.ts
+++ b/frontend/src/i18n/translations/es-ES.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Debe ser un número",
   "common.error.field-required": "Este campo es requerido",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/et-EE.ts
+++ b/frontend/src/i18n/translations/et-EE.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Peab olema number",
   "common.error.field-required": "See väli on kohustuslik",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/fi-FI.ts
+++ b/frontend/src/i18n/translations/fi-FI.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Pitää olla luku",
   "common.error.field-required": "Tämä kenttä on pakollinen",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/fr-FR.ts
+++ b/frontend/src/i18n/translations/fr-FR.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Doit être un nombre",
   "common.error.field-required": "Ce champ est obligatoire",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/hr-HR.ts
+++ b/frontend/src/i18n/translations/hr-HR.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Mora biti broj",
   "common.error.field-required": "Polje je obavezno",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/hu-HU.ts
+++ b/frontend/src/i18n/translations/hu-HU.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Számot kell megadnia",
   "common.error.field-required": "Ez egy kötelező mező",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/it-IT.ts
+++ b/frontend/src/i18n/translations/it-IT.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Deve essere un numero",
   "common.error.field-required": "Questo campo è obbligatorio",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/ja-JP.ts
+++ b/frontend/src/i18n/translations/ja-JP.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "数字でなければなりません",
   "common.error.field-required": "これは必須項目です",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/ko-KR.ts
+++ b/frontend/src/i18n/translations/ko-KR.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "숫자만 가능합니다.",
   "common.error.field-required": "이 필드는 필수입니다",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/nl-BE.ts
+++ b/frontend/src/i18n/translations/nl-BE.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Moet een getal zijn",
   "common.error.field-required": "Dit veld is verplicht",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/pl-PL.ts
+++ b/frontend/src/i18n/translations/pl-PL.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Musi być liczbą",
   "common.error.field-required": "To pole jest wymagane",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/pt-BR.ts
+++ b/frontend/src/i18n/translations/pt-BR.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Tem que ser um número",
   "common.error.field-required": "Este campo é obrigatório",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/ru-RU.ts
+++ b/frontend/src/i18n/translations/ru-RU.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Должно быть числом",
   "common.error.field-required": "Поле обязательно для заполнения",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/sl-SI.ts
+++ b/frontend/src/i18n/translations/sl-SI.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Mora biti številka",
   "common.error.field-required": "To polje je obvezno",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/sr-CS.ts
+++ b/frontend/src/i18n/translations/sr-CS.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Mora biti broj",
   "common.error.field-required": "Polje je obavezno",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/sr-SP.ts
+++ b/frontend/src/i18n/translations/sr-SP.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Мора бити број",
   "common.error.field-required": "Поље је обавезно",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/sv-SE.ts
+++ b/frontend/src/i18n/translations/sv-SE.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Måste vara ett tal",
   "common.error.field-required": "Obligatoriskt fält",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/th-TH.ts
+++ b/frontend/src/i18n/translations/th-TH.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "ต้องเป็นตัวเลข",
   "common.error.field-required": "ต้องกรอกข้อมูลนี้",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/tr-TR.ts
+++ b/frontend/src/i18n/translations/tr-TR.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Bir sayı olmalıdır",
   "common.error.field-required": "Bu alan zorunludur",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/uk-UA.ts
+++ b/frontend/src/i18n/translations/uk-UA.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Повинно бути числом",
   "common.error.field-required": "Поле обов'язкове для заповнення",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/vi-VN.ts
+++ b/frontend/src/i18n/translations/vi-VN.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "Phải là số",
   "common.error.field-required": "Trường bắt buộc",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "必须为数字",
   "common.error.field-required": "必填项",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/zh-TW.ts
+++ b/frontend/src/i18n/translations/zh-TW.ts
@@ -546,6 +546,6 @@ export default {
   "common.error.invalid-number": "必須為數字",
   "common.error.field-required": "必填",
   "admin.config.category.gallery": "Gallery",
-  "admin.config.gallery.enable-by-default": "Enable gallery by default",
-  "admin.config.gallery.enable-by-default.description": "New shares will have the gallery option enabled by default.",
+  "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
+  "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -51,7 +51,8 @@ const Upload = ({
 
   maxShareSize ??= parseInt(config.get("share.maxSize"));
   const autoOpenCreateUploadModal = config.get("share.autoOpenShareModal");
-  const galleryEnabledByDefault = config.get("gallery.enableByDefault");
+  const galleryFilenameRegex = config.get("gallery.filenameRegex");
+  const galleryRegex = new RegExp(galleryFilenameRegex, "i");
 
   const uploadFiles = async (share: CreateShare, files: FileUpload[]) => {
     setisUploading(true);
@@ -100,6 +101,7 @@ const Upload = ({
                 {
                   id: fileId,
                   name: file.name,
+                  isGallery: file.isGallery,
                 },
                 chunkIndex,
                 chunks,
@@ -146,7 +148,6 @@ const Upload = ({
         maxExpiration: config.get("share.maxExpiration"),
         shareIdLength: config.get("share.shareIdLength"),
         simplified,
-        galleryEnabledByDefault,
       },
       files,
       uploadFiles,
@@ -154,6 +155,12 @@ const Upload = ({
   };
 
   const handleDropzoneFilesChanged = (files: FileUpload[]) => {
+    files = files.map((file) => {
+      if (file.name.endsWith(".zip")) {
+        file.isGallery = galleryRegex.test(file.name);
+      }
+      return file;
+    });
     if (autoOpenCreateUploadModal) {
       setFiles(files);
       showCreateUploadModalCallback(files);

--- a/frontend/src/services/share.service.ts
+++ b/frontend/src/services/share.service.ts
@@ -90,6 +90,7 @@ const uploadFile = async (
   file: {
     id?: string;
     name: string;
+    isGallery?: boolean;
   },
   chunkIndex: number,
   totalChunks: number,
@@ -102,6 +103,7 @@ const uploadFile = async (
         name: file.name,
         chunkIndex,
         totalChunks,
+        isGallery: file.isGallery,
       },
     })
   ).data;

--- a/frontend/src/types/File.type.ts
+++ b/frontend/src/types/File.type.ts
@@ -1,4 +1,7 @@
-export type FileUpload = File & { uploadingProgress: number };
+export type FileUpload = File & {
+  uploadingProgress: number;
+  isGallery?: boolean;
+};
 
 export type FileUploadResponse = { id: string; name: string };
 
@@ -6,6 +9,7 @@ export type FileMetaData = {
   id: string;
   name: string;
   size: string;
+  isGallery?: boolean;
 };
 
 export type FileListItem = FileUpload | (FileMetaData & { deleted?: boolean });

--- a/frontend/src/types/share.type.ts
+++ b/frontend/src/types/share.type.ts
@@ -1,15 +1,21 @@
 import User from "./user.type";
 
+export type ShareFile = {
+  id: string;
+  name: string;
+  size: string;
+  isGallery?: boolean;
+};
+
 export type Share = {
   id: string;
   name?: string;
-  files: any;
+  files: ShareFile[];
   creator?: User;
   description?: string;
   expiration: Date;
   size: number;
   hasPassword: boolean;
-  isGallery: boolean;
 };
 
 export type CompletedShare = Share & {
@@ -28,7 +34,6 @@ export type CreateShare = {
   recipients: string[];
   expiration: string;
   security: ShareSecurity;
-  isGallery?: boolean;
 };
 
 export type ShareMetaData = {


### PR DESCRIPTION
## Summary
- allow marking individual ZIP files for gallery extraction
- persist gallery flag on files and extract images only for marked ZIPs
- add UI checkbox for ZIP uploads and send flag to backend
- configure gallery default with filename regex and default to `jpegs?\.zip`

## Testing
- `npx prisma generate`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68aa32d8a360832bad80c7c211d9830a