### PR TITLE
feat: add gallery auto-enable toggle

### DIFF
--- a/backend/prisma/migrations/20251003000000_gallery_auto_enable/migration.sql
+++ b/backend/prisma/migrations/20251003000000_gallery_auto_enable/migration.sql
@@ -1,0 +1,9 @@
+INSERT INTO "Config" ("name", "category", "type", "defaultValue", "value", "obscured", "secret", "locked", "order", "updatedAt")
+SELECT 'autoEnable', 'gallery', 'boolean', 'true', NULL, false, false, false, 0, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM "Config" WHERE "name" = 'autoEnable' AND "category" = 'gallery'
+);
+
+UPDATE "Config"
+SET "order" = 1
+WHERE "name" = 'filenameRegex' AND "category" = 'gallery';

--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -77,6 +77,11 @@ export const configVariables = {
     },
   },
   gallery: {
+    autoEnable: {
+      type: "boolean",
+      defaultValue: "true",
+      secret: false,
+    },
     filenameRegex: {
       type: "string",
       defaultValue: "jpegs?\\.zip$",

--- a/frontend/src/i18n/translations/ar-EG.ts
+++ b/frontend/src/i18n/translations/ar-EG.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "يجب أن يكون رقماً",
   "common.error.field-required": "هذا الحقل مطلوب",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/cs-CZ.ts
+++ b/frontend/src/i18n/translations/cs-CZ.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Musí být číslo",
   "common.error.field-required": "Toto pole je povinné",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/da-DK.ts
+++ b/frontend/src/i18n/translations/da-DK.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Skal være et tal",
   "common.error.field-required": "Dette felt er påkrævet",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/de-DE.ts
+++ b/frontend/src/i18n/translations/de-DE.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Muss eine Zahl sein",
   "common.error.field-required": "Dieses Feld ist erforderlich",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/el-GR.ts
+++ b/frontend/src/i18n/translations/el-GR.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Πρέπει να είναι αριθμός",
   "common.error.field-required": "Αυτό το πεδίο είναι υποχρεωτικό",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -764,6 +764,8 @@ export default {
   "common.error.invalid-number": "Must be a number",
   "common.error.field-required": "This field is required",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/es-ES.ts
+++ b/frontend/src/i18n/translations/es-ES.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Debe ser un número",
   "common.error.field-required": "Este campo es requerido",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/et-EE.ts
+++ b/frontend/src/i18n/translations/et-EE.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Peab olema number",
   "common.error.field-required": "See väli on kohustuslik",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/fi-FI.ts
+++ b/frontend/src/i18n/translations/fi-FI.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Pitää olla luku",
   "common.error.field-required": "Tämä kenttä on pakollinen",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/fr-FR.ts
+++ b/frontend/src/i18n/translations/fr-FR.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Doit être un nombre",
   "common.error.field-required": "Ce champ est obligatoire",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/hr-HR.ts
+++ b/frontend/src/i18n/translations/hr-HR.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Mora biti broj",
   "common.error.field-required": "Polje je obavezno",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/hu-HU.ts
+++ b/frontend/src/i18n/translations/hu-HU.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Számot kell megadnia",
   "common.error.field-required": "Ez egy kötelező mező",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/it-IT.ts
+++ b/frontend/src/i18n/translations/it-IT.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Deve essere un numero",
   "common.error.field-required": "Questo campo è obbligatorio",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/ja-JP.ts
+++ b/frontend/src/i18n/translations/ja-JP.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "数字でなければなりません",
   "common.error.field-required": "これは必須項目です",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/ko-KR.ts
+++ b/frontend/src/i18n/translations/ko-KR.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "숫자만 가능합니다.",
   "common.error.field-required": "이 필드는 필수입니다",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/nl-BE.ts
+++ b/frontend/src/i18n/translations/nl-BE.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Moet een getal zijn",
   "common.error.field-required": "Dit veld is verplicht",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/pl-PL.ts
+++ b/frontend/src/i18n/translations/pl-PL.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Musi być liczbą",
   "common.error.field-required": "To pole jest wymagane",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/pt-BR.ts
+++ b/frontend/src/i18n/translations/pt-BR.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Tem que ser um número",
   "common.error.field-required": "Este campo é obrigatório",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/ru-RU.ts
+++ b/frontend/src/i18n/translations/ru-RU.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Должно быть числом",
   "common.error.field-required": "Поле обязательно для заполнения",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/sl-SI.ts
+++ b/frontend/src/i18n/translations/sl-SI.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Mora biti številka",
   "common.error.field-required": "To polje je obvezno",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/sr-CS.ts
+++ b/frontend/src/i18n/translations/sr-CS.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Mora biti broj",
   "common.error.field-required": "Polje je obavezno",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/sr-SP.ts
+++ b/frontend/src/i18n/translations/sr-SP.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Мора бити број",
   "common.error.field-required": "Поље је обавезно",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/sv-SE.ts
+++ b/frontend/src/i18n/translations/sv-SE.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Måste vara ett tal",
   "common.error.field-required": "Obligatoriskt fält",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/th-TH.ts
+++ b/frontend/src/i18n/translations/th-TH.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "ต้องเป็นตัวเลข",
   "common.error.field-required": "ต้องกรอกข้อมูลนี้",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/tr-TR.ts
+++ b/frontend/src/i18n/translations/tr-TR.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Bir sayı olmalıdır",
   "common.error.field-required": "Bu alan zorunludur",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/uk-UA.ts
+++ b/frontend/src/i18n/translations/uk-UA.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Повинно бути числом",
   "common.error.field-required": "Поле обов'язкове для заповнення",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/vi-VN.ts
+++ b/frontend/src/i18n/translations/vi-VN.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "Phải là số",
   "common.error.field-required": "Trường bắt buộc",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "必须为数字",
   "common.error.field-required": "必填项",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/i18n/translations/zh-TW.ts
+++ b/frontend/src/i18n/translations/zh-TW.ts
@@ -546,6 +546,8 @@ export default {
   "common.error.invalid-number": "必須為數字",
   "common.error.field-required": "必填",
   "admin.config.category.gallery": "Gallery",
+  "admin.config.gallery.auto-enable": "Auto-enable gallery based on regex",
+  "admin.config.gallery.auto-enable.description": "Automatically enable gallery view for ZIP files whose filenames match the regex.",
   "admin.config.gallery.filename-regex": "Auto-enable gallery regex",
   "admin.config.gallery.filename-regex.description": "ZIP filenames matching this regular expression (case-insensitive) will enable gallery by default.",
 };

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -51,6 +51,7 @@ const Upload = ({
 
   maxShareSize ??= parseInt(config.get("share.maxSize"));
   const autoOpenCreateUploadModal = config.get("share.autoOpenShareModal");
+  const galleryAutoEnable = config.get("gallery.autoEnable");
   const galleryFilenameRegex = config.get("gallery.filenameRegex");
   const galleryRegex = new RegExp(galleryFilenameRegex, "i");
 
@@ -157,7 +158,7 @@ const Upload = ({
   const handleDropzoneFilesChanged = (files: FileUpload[]) => {
     files = files.map((file) => {
       if (file.name.endsWith(".zip")) {
-        file.isGallery = galleryRegex.test(file.name);
+        file.isGallery = galleryAutoEnable && galleryRegex.test(file.name);
       }
       return file;
     });


### PR DESCRIPTION
## Summary
- add boolean setting to enable gallery auto detection
- seed and migrate new gallery auto-enable config
- gate upload gallery matching behind new setting and add translations

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab75809164832ba3e2a2c075973236